### PR TITLE
Add examples for copying captures and videos 

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,25 +334,25 @@ SUBCOMMANDS:
 
 #### Examples
 
-| Command                                                           	    | Action                                                                            	|
-|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| `menyoki record`                                                      	| Select a window and start recording with default settings                         	|
-| `menyoki record --root --countdown 5`                                 	| Record the root window after 5 seconds of countdown                               	|
-| `menyoki record --focus --with-alpha`                                 	| Record the focused window with the alpha channel (for transparency)               	|
-| `menyoki record --size 200x300 --duration 10`                         	| Record an area of size 200x300 for 10 seconds                                     	|
-| `menyoki record --padding 20:10:0:10 --timeout 120`                   	| Record an area with given padding and set window selection timeout to 120 seconds 	|
-| `menyoki record --parent`                                             	| Record the parent window of the selected window                                   	|
-| `menyoki record --root --select --monitor 1`                          	| Record the first monitor as root window                                           	|
-| `menyoki record --border 5`                                           	| Record the area selected by a border with 5 width                                 	|
-| `menyoki record --keys LControl-Q/W`                                  	| Record with the default settings using custom key bindings                        	|
-| `menyoki record gif --fps 15 --quality 90`                            	| Record 15 frames per second with 90% quality                                      	|
-| `menyoki record gif --gifski`                                         	| Record and encode using the gifski encoder                                        	|
-| `menyoki record gif save "test.gif" --timestamp`                      	| Record and save as "test.gif" with timestamp in the file name                     	|
-| `menyoki record apng --fps 30`                                    	    | Record 30 frames per second and encode as APNG                                    	|
-| `menyoki -q record save "-" > test.gif`                           	    | Record and redirect output to "test.gif"                                          	|
-| `menyoki -q record save "-" | xclip -selection clipboard -t image/gif`    | Record and pipes output to xclip's clipboard selection, specifying target as a gif    |
-| `menyoki -q record "kmon -t 2000"`                                	    | Execute the command and record its output in quiet mode                          	    |
-| `menyoki record --font "-*-dejavu sans-*-*-*-*-17-*-*-*-*-*-*-*"` 	    | Use custom font for showing the area size (see `xfontsel`)                       	    |
+| Command                                                           	     | Action                                                                            	|
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `menyoki record`                                                      	 | Select a window and start recording with default settings                         	|
+| `menyoki record --root --countdown 5`                                 	 | Record the root window after 5 seconds of countdown                               	|
+| `menyoki record --focus --with-alpha`                                 	 | Record the focused window with the alpha channel (for transparency)               	|
+| `menyoki record --size 200x300 --duration 10`                         	 | Record an area of size 200x300 for 10 seconds                                     	|
+| `menyoki record --padding 20:10:0:10 --timeout 120`                   	 | Record an area with given padding and set window selection timeout to 120 seconds 	|
+| `menyoki record --parent`                                             	 | Record the parent window of the selected window                                   	|
+| `menyoki record --root --select --monitor 1`                          	 | Record the first monitor as root window                                           	|
+| `menyoki record --border 5`                                           	 | Record the area selected by a border with 5 width                                 	|
+| `menyoki record --keys LControl-Q/W`                                  	 | Record with the default settings using custom key bindings                        	|
+| `menyoki record gif --fps 15 --quality 90`                            	 | Record 15 frames per second with 90% quality                                      	|
+| `menyoki record gif --gifski`                                         	 | Record and encode using the gifski encoder                                        	|
+| `menyoki record gif save "test.gif" --timestamp`                      	 | Record and save as "test.gif" with timestamp in the file name                     	|
+| `menyoki record apng --fps 30`                                    	     | Record 30 frames per second and encode as APNG                                    	|
+| `menyoki -q record save "-" > test.gif`                           	     | Record and redirect output to "test.gif"                                          	|
+| `menyoki -q record save "-" \| xclip -selection clipboard -t image/gif`    | Record and pipes output to xclip's clipboard selection, specifying target as a gif   |
+| `menyoki -q record "kmon -t 2000"`                                	     | Execute the command and record its output in quiet mode                              |
+| `menyoki record --font "-*-dejavu sans-*-*-*-*-17-*-*-*-*-*-*-*"` 	     | Use custom font for showing the area size (see `xfontsel`)                           |
 
 #### Pro Tip
 
@@ -483,20 +483,20 @@ SUBCOMMANDS:
 
 #### Examples
 
-| Command                                                                     | Action                                                                                       	|
-|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| `menyoki capture`                                                           | Select a window and screenshot with default settings                                         	|
-| `menyoki capture --root --countdown 5`                                      | Screenshot the root window after 5 seconds of countdown                                      	|
-| `menyoki capture --focus --with-alpha`                                      | Screenshot the focused window with the alpha channel (for transparency)                      	|
-| `menyoki capture --size 200x300 --duration 10`                              | Screenshot an area of size 200x300 for 10 seconds                                            	|
-| `menyoki capture --padding 20:10:0:10 --timeout 120`                        | Screenshot an area with given padding and set window selection timeout to 120 seconds        	|
-| `menyoki capture png --filter avg --compression fast`                       | Screenshot and encode with the specified PNG options                                         	|
-| `menyoki capture jpg --quality 100`                                         | Screenshot and encode with the specified JPEG options                                        	|
-| `menyoki capture pnm --format pixmap --encoding ascii`                      | Screenshot and encode with the specified PNM options                                         	|
-| `menyoki capture ff save "test.ff" --timestamp`                             | Screenshot and save as "test.ff" in farbfeld format with timestamp in the file name          	|
-| `menyoki -q capture png save "-" > test.png`                                | Screenshot and redirect output to "test.png"                                                 	|
-| `menyoki -q capture png save "-" | xclip -selection clipboard -t image/png` | Screenshot and pipe output to xclip's clipboard selection, specifying an image/png target     	|
-| `menyoki -q capture "kmon -t 2000"`                    	                  | Execute the command and screenshot its output in quiet mode (sets countdown to 3 implicitly) 	|
+| Command                                                                      | Action                                                                                       	|
+|------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `menyoki capture`                                                            | Select a window and screenshot with default settings                                         	|
+| `menyoki capture --root --countdown 5`                                       | Screenshot the root window after 5 seconds of countdown                                      	|
+| `menyoki capture --focus --with-alpha`                                       | Screenshot the focused window with the alpha channel (for transparency)                      	|
+| `menyoki capture --size 200x300 --duration 10`                               | Screenshot an area of size 200x300 for 10 seconds                                            	|
+| `menyoki capture --padding 20:10:0:10 --timeout 120`                         | Screenshot an area with given padding and set window selection timeout to 120 seconds        	|
+| `menyoki capture png --filter avg --compression fast`                        | Screenshot and encode with the specified PNG options                                         	|
+| `menyoki capture jpg --quality 100`                                          | Screenshot and encode with the specified JPEG options                                        	|
+| `menyoki capture pnm --format pixmap --encoding ascii`                       | Screenshot and encode with the specified PNM options                                         	|
+| `menyoki capture ff save "test.ff" --timestamp`                              | Screenshot and save as "test.ff" in farbfeld format with timestamp in the file name          	|
+| `menyoki -q capture png save "-" > test.png`                                 | Screenshot and redirect output to "test.png"                                                 	|
+| `menyoki -q capture png save "-" \| xclip -selection clipboard -t image/png` | Screenshot and pipe output to xclip's clipboard selection, specifying an image/png target     	|
+| `menyoki -q capture "kmon -t 2000"`                    	                   | Execute the command and screenshot its output in quiet mode (sets countdown to 3 implicitly) 	|
 
 Also, see the [pro tip](#pro-tip) about `--size` argument.
 

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ cargo install --path .
 
 ## Usage
 
-| Action                                                                                                                     	| Result                                                                                                          	|
-|----------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
+| Action                                                                                                                     	| Result                                                                                                          	        |
+|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | ![menyoki on action](https://user-images.githubusercontent.com/24392180/99543947-cdeb2280-29c4-11eb-87a9-ad559f9522ad.gif) 	| ![record result](https://user-images.githubusercontent.com/24392180/99814600-3cadb480-2b5a-11eb-84ce-1a693d5ddc2c.gif) 	|
 
 Command line arguments of **menyoki** are designed to be as intuitive as possible. As a result of that, an action can be performed with a chain of subcommands along with the flags and options. The general prototype for the usage of command line arguments is the following:
@@ -280,7 +280,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                               	| Action                                                                  	|
-|---------------------------------------	|-------------------------------------------------------------------------	|
+|-------------------------------------------|---------------------------------------------------------------------------|
 | `menyoki -V`                          	| Print the version information                                           	|
 | `menyoki -vv --color FF00FF <action>` 	| Set log verbosity level to 2 (trace) and use "FF00FF" as the main color 	|
 | `menyoki -q -c menyoki.conf <action>`  	| Run in quiet mode and read the configuration from "menyoki.conf"         	|
@@ -335,7 +335,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                                                           	    | Action                                                                            	|
-|-------------------------------------------------------------------     	|-----------------------------------------------------------------------------------	|
+|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | `menyoki record`                                                      	| Select a window and start recording with default settings                         	|
 | `menyoki record --root --countdown 5`                                 	| Record the root window after 5 seconds of countdown                               	|
 | `menyoki record --focus --with-alpha`                                 	| Record the focused window with the alpha channel (for transparency)               	|
@@ -350,7 +350,7 @@ SUBCOMMANDS:
 | `menyoki record gif save "test.gif" --timestamp`                      	| Record and save as "test.gif" with timestamp in the file name                     	|
 | `menyoki record apng --fps 30`                                    	    | Record 30 frames per second and encode as APNG                                    	|
 | `menyoki -q record save "-" > test.gif`                           	    | Record and redirect output to "test.gif"                                          	|
-| `menyoki -q record save "-" | xclip -selection clipboard -t image/gif`    | Record and pipes output to xclip's clipboard selection, specifying target as a gif |
+| `menyoki -q record save "-" | xclip -selection clipboard -t image/gif`    | Record and pipes output to xclip's clipboard selection, specifying target as a gif    |
 | `menyoki -q record "kmon -t 2000"`                                	    | Execute the command and record its output in quiet mode                          	    |
 | `menyoki record --font "-*-dejavu sans-*-*-*-*-17-*-*-*-*-*-*-*"` 	    | Use custom font for showing the area size (see `xfontsel`)                       	    |
 
@@ -394,7 +394,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                                   	| Action                                                  	|
-|-------------------------------------------	|---------------------------------------------------------	|
+|-----------------------------------------------|-----------------------------------------------------------|
 | `menyoki split rec.gif`                   	| Extract frames from the "rec.gif" file                  	|
 | `menyoki split rec.gif jpg --quality 100` 	| Extract frames as JPEG in maximum quality               	|
 | `menyoki split rec.gif --dir frames/`     	| Extract frames and save them to the specified directory 	|
@@ -431,7 +431,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                                          	| Action                                                           	|
-|--------------------------------------------------	|------------------------------------------------------------------	|
+|---------------------------------------------------|-------------------------------------------------------------------|
 | `menyoki make 1.png 2.png`                       	| Make a GIF that consists of two frames as "1.png" and "2.png"    	|
 | `menyoki make 1.png 2.png --fps 5 --quality 100` 	| Make a GIF with the specified properties from given frames       	|
 | `menyoki make 1.png 2.png save 3.gif --date`     	| Make a GIF and save the file ("3.gif") with the date information 	|
@@ -484,7 +484,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                                                                     | Action                                                                                       	|
-|--------------------------------------------------------                     |----------------------------------------------------------------------------------------------	|
+|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | `menyoki capture`                                                           | Select a window and screenshot with default settings                                         	|
 | `menyoki capture --root --countdown 5`                                      | Screenshot the root window after 5 seconds of countdown                                      	|
 | `menyoki capture --focus --with-alpha`                                      | Screenshot the focused window with the alpha channel (for transparency)                      	|
@@ -548,7 +548,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                                                                                                            	| Action                                                         	|
-|--------------------------------------------------------------------------------------------------------------------	|----------------------------------------------------------------	|
+|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | `menyoki edit test.png`                                                                                            	| Re-encode the "test.png" file without editing                  	|
 | `menyoki edit test.png --grayscale`                                                                                	| Convert image to grayscale                                     	|
 | `menyoki edit test.png --invert`                                                                                   	| Invert the colors of the image                                 	|
@@ -596,7 +596,7 @@ SUBCOMMANDS:
 #### Examples
 
 | Command                                                 	| Action                                                        	|
-|---------------------------------------------------------	|---------------------------------------------------------------	|
+|-----------------------------------------------------------|-------------------------------------------------------------------|
 | `menyoki analyze test.jpg`                              	| Inspect "test.jpg" and print the report                       	|
 | `menyoki analyze test.jpg save test_report.txt`         	| Inspect "test.jpg" and save the report as "test_report.txt"   	|
 | `menyoki analyze test.jpg --timestamp`                  	| Inspect the file and create a report based on timestamps      	|
@@ -772,7 +772,7 @@ There are 3 types of key bindings in terms of performed action:
 * Miscellaneous keys (the keys that can be used for resizing the selected area such as `LAlt-[up]`)
 
 | Key                               	| Action                                                      	|
-|-----------------------------------	|-------------------------------------------------------------	|
+|---------------------------------------|---------------------------------------------------------------|
 | `LAlt-[S/Enter]`                  	| Start/stop recording or screenshot the selected area        	|
 | `LControl-D, Escape`              	| Cancel the current operation                                	|
 | `LControl-C`                      	| Cancel the current operation or stop recording              	|
@@ -924,7 +924,7 @@ Corresponding environment variables can be set for overriding the command line f
 ### Examples
 
 | Command                                                     	| Environment Variables                                     	|
-|-------------------------------------------------------------	|-----------------------------------------------------------	|
+|---------------------------------------------------------------|---------------------------------------------------------------|
 | `menyoki --quiet`                                           	| `MENYOKI_GENERAL_QUIET=true`                              	|
 | `menyoki record gif --fps 10 save --timestamp`              	| `MENYOKI_GIF_FPS=10 MENYOKI_SAVE_TIMESTAMP=true`          	|
 | `menyoki capture --size 200x300 jpg --quality 100`          	| `MENYOKI_CAPTURE_SIZE=200x300 MENYOKI_JPG_QUALITY=100`    	|

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ cargo install --path .
 |----------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
 | ![menyoki on action](https://user-images.githubusercontent.com/24392180/99543947-cdeb2280-29c4-11eb-87a9-ad559f9522ad.gif) 	| ![record result](https://user-images.githubusercontent.com/24392180/99814600-3cadb480-2b5a-11eb-84ce-1a693d5ddc2c.gif) 	|
 
-Command line arguments of **menyoki** are designed to be as intuitive as possible. As a result of that, an action can be performed with a chain of subcommands along with the flags and options. The general prototype for the usage of command line arguments is the following: 
+Command line arguments of **menyoki** are designed to be as intuitive as possible. As a result of that, an action can be performed with a chain of subcommands along with the flags and options. The general prototype for the usage of command line arguments is the following:
 
 `menyoki (ACTION) (FORMAT) (OUTPUT)`
 
@@ -334,24 +334,25 @@ SUBCOMMANDS:
 
 #### Examples
 
-| Command                                                           	| Action                                                                            	|
-|-------------------------------------------------------------------	|-----------------------------------------------------------------------------------	|
-| `menyoki record`                                                  	| Select a window and start recording with default settings                         	|
-| `menyoki record --root --countdown 5`                             	| Record the root window after 5 seconds of countdown                               	|
-| `menyoki record --focus --with-alpha`                             	| Record the focused window with the alpha channel (for transparency)               	|
-| `menyoki record --size 200x300 --duration 10`                     	| Record an area of size 200x300 for 10 seconds                                     	|
-| `menyoki record --padding 20:10:0:10 --timeout 120`               	| Record an area with given padding and set window selection timeout to 120 seconds 	|
-| `menyoki record --parent`                                         	| Record the parent window of the selected window                                   	|
-| `menyoki record --root --select --monitor 1`                      	| Record the first monitor as root window                                           	|
-| `menyoki record --border 5`                                       	| Record the area selected by a border with 5 width                                 	|
-| `menyoki record --keys LControl-Q/W`                              	| Record with the default settings using custom key bindings                        	|
-| `menyoki record gif --fps 15 --quality 90`                        	| Record 15 frames per second with 90% quality                                      	|
-| `menyoki record gif --gifski`                                     	| Record and encode using the gifski encoder                                        	|
-| `menyoki record gif save "test.gif" --timestamp`                  	| Record and save as "test.gif" with timestamp in the file name                     	|
-| `menyoki record apng --fps 30`                                    	| Record 30 frames per second and encode as APNG                                    	|
-| `menyoki -q record save "-" > test.gif`                           	| Record and redirect output to "test.gif"                                          	|
-| `menyoki -q record "kmon -t 2000"`                                	| Execute the command and record its output in quiet mode                           	|
-| `menyoki record --font "-*-dejavu sans-*-*-*-*-17-*-*-*-*-*-*-*"` 	| Use custom font for showing the area size (see `xfontsel`)                        	|
+| Command                                                           	    | Action                                                                            	|
+|-------------------------------------------------------------------     	|-----------------------------------------------------------------------------------	|
+| `menyoki record`                                                      	| Select a window and start recording with default settings                         	|
+| `menyoki record --root --countdown 5`                                 	| Record the root window after 5 seconds of countdown                               	|
+| `menyoki record --focus --with-alpha`                                 	| Record the focused window with the alpha channel (for transparency)               	|
+| `menyoki record --size 200x300 --duration 10`                         	| Record an area of size 200x300 for 10 seconds                                     	|
+| `menyoki record --padding 20:10:0:10 --timeout 120`                   	| Record an area with given padding and set window selection timeout to 120 seconds 	|
+| `menyoki record --parent`                                             	| Record the parent window of the selected window                                   	|
+| `menyoki record --root --select --monitor 1`                          	| Record the first monitor as root window                                           	|
+| `menyoki record --border 5`                                           	| Record the area selected by a border with 5 width                                 	|
+| `menyoki record --keys LControl-Q/W`                                  	| Record with the default settings using custom key bindings                        	|
+| `menyoki record gif --fps 15 --quality 90`                            	| Record 15 frames per second with 90% quality                                      	|
+| `menyoki record gif --gifski`                                         	| Record and encode using the gifski encoder                                        	|
+| `menyoki record gif save "test.gif" --timestamp`                      	| Record and save as "test.gif" with timestamp in the file name                     	|
+| `menyoki record apng --fps 30`                                    	    | Record 30 frames per second and encode as APNG                                    	|
+| `menyoki -q record save "-" > test.gif`                           	    | Record and redirect output to "test.gif"                                          	|
+| `menyoki -q record save "-" | xclip -selection clipboard -t image/gif`    | Record and pipes output to xclip's clipboard selection, specifying target as a gif |
+| `menyoki -q record "kmon -t 2000"`                                	    | Execute the command and record its output in quiet mode                          	    |
+| `menyoki record --font "-*-dejavu sans-*-*-*-*-17-*-*-*-*-*-*-*"` 	    | Use custom font for showing the area size (see `xfontsel`)                       	    |
 
 #### Pro Tip
 
@@ -482,19 +483,20 @@ SUBCOMMANDS:
 
 #### Examples
 
-| Command                                                	| Action                                                                                       	|
-|--------------------------------------------------------	|----------------------------------------------------------------------------------------------	|
-| `menyoki capture`                                      	| Select a window and screenshot with default settings                                         	|
-| `menyoki capture --root --countdown 5`                 	| Screenshot the root window after 5 seconds of countdown                                      	|
-| `menyoki capture --focus --with-alpha`                 	| Screenshot the focused window with the alpha channel (for transparency)                      	|
-| `menyoki capture --size 200x300 --duration 10`         	| Screenshot an area of size 200x300 for 10 seconds                                            	|
-| `menyoki capture --padding 20:10:0:10 --timeout 120`   	| Screenshot an area with given padding and set window selection timeout to 120 seconds        	|
-| `menyoki capture png --filter avg --compression fast`  	| Screenshot and encode with the specified PNG options                                         	|
-| `menyoki capture jpg --quality 100`                    	| Screenshot and encode with the specified JPEG options                                        	|
-| `menyoki capture pnm --format pixmap --encoding ascii` 	| Screenshot and encode with the specified PNM options                                         	|
-| `menyoki capture ff save "test.ff" --timestamp`        	| Screenshot and save as "test.ff" in farbfeld format with timestamp in the file name          	|
-| `menyoki -q capture png save "-" > test.png`           	| Screenshot and redirect output to "test.png"                                                 	|
-| `menyoki -q capture "kmon -t 2000"`                    	| Execute the command and screenshot its output in quiet mode (sets countdown to 3 implicitly) 	|
+| Command                                                                     | Action                                                                                       	|
+|--------------------------------------------------------                     |----------------------------------------------------------------------------------------------	|
+| `menyoki capture`                                                           | Select a window and screenshot with default settings                                         	|
+| `menyoki capture --root --countdown 5`                                      | Screenshot the root window after 5 seconds of countdown                                      	|
+| `menyoki capture --focus --with-alpha`                                      | Screenshot the focused window with the alpha channel (for transparency)                      	|
+| `menyoki capture --size 200x300 --duration 10`                              | Screenshot an area of size 200x300 for 10 seconds                                            	|
+| `menyoki capture --padding 20:10:0:10 --timeout 120`                        | Screenshot an area with given padding and set window selection timeout to 120 seconds        	|
+| `menyoki capture png --filter avg --compression fast`                       | Screenshot and encode with the specified PNG options                                         	|
+| `menyoki capture jpg --quality 100`                                         | Screenshot and encode with the specified JPEG options                                        	|
+| `menyoki capture pnm --format pixmap --encoding ascii`                      | Screenshot and encode with the specified PNM options                                         	|
+| `menyoki capture ff save "test.ff" --timestamp`                             | Screenshot and save as "test.ff" in farbfeld format with timestamp in the file name          	|
+| `menyoki -q capture png save "-" > test.png`                                | Screenshot and redirect output to "test.png"                                                 	|
+| `menyoki -q capture png save "-" | xclip -selection clipboard -t image/png` | Screenshot and pipe output to xclip's clipboard selection, specifying an image/png target     	|
+| `menyoki -q capture "kmon -t 2000"`                    	                  | Execute the command and screenshot its output in quiet mode (sets countdown to 3 implicitly) 	|
 
 Also, see the [pro tip](#pro-tip) about `--size` argument.
 
@@ -823,19 +825,19 @@ countdown = 3
 timeout = 60
 interval = 10
 #font =
-#monitor = 
-#command = 
+#monitor =
+#command =
 
 [split]
-#dir = 
-#file = 
+#dir =
+#file =
 
 [make]
 #no-sort = false
 fps = 20
 quality = 75
 repeat = ∞
-#dir = 
+#dir =
 format = gif
 
 [capture]
@@ -852,8 +854,8 @@ countdown = 0
 timeout = 60
 interval = 10
 #font =
-#monitor = 
-#command = 
+#monitor =
+#command =
 
 [edit]
 convert = false
@@ -862,25 +864,25 @@ invert = false
 #crop = T:R:B:L
 #resize = WxH
 ratio = 1.0
-#rotate = 
-#flip = 
+#rotate =
+#flip =
 blur = 0.0
 hue = ±0
 contrast = ±0.0
 brightness = ±0
 filter = lanczos3
-#file = 
+#file =
 
 [analyze]
 timestamp = false
 time-zone = utc
-#file = 
+#file =
 
 [save]
 with-extension = false
 timestamp = false
 date = %Y%m%dT%H%M%S
-#file = 
+#file =
 
 [gif]
 gifski = false


### PR DESCRIPTION
## Description
Added two examples to the capture and record commands, my editor also stripped some spaces after the lines automatically, and I made tables more consistent.

## Motivation and Context
It was added to ease beginners into using this, and to show how to use the save subcommand's `"-"` option in conjunction with xclip.

## How Has This Been Tested?
using `cargo test` goes fine, but using `cargo test --features test-ws` produces two errors:
```
test x11::window::tests::test_x11_window ... FAILED
test x11::tests::test_x11_system ... FAILED
```
I haven't exactly changed anything in the other code, so I'm not sure

After running those two commands:
```
cargo fmt --all -- --check --verbose
cargo clippy --verbose -- -D warnings
```
Everything seems to work except for one thing:
```
    Checking menyoki v1.2.1 (/home/mon/Git/menyoki)
     Running `/home/mon/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/clippy-driver rustc --crate-name menyoki --edition=2018 src/main.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,metadata -C opt-level=2 -C panic=abort -C embed-bitcode=no -C debuginfo=2 -C debug-assertions=on --cfg 'feature="default"' --cfg 'feature="gifski"' --cfg 'feature="imgref"' --cfg 'feature="rgb"' --cfg 'feature="ski"' -C metadata=74d57682c096c4a4 -C extra-filename=-74d57682c096c4a4 --out-dir /home/mon/Git/menyoki/target/debug/deps -C incremental=/home/mon/Git/menyoki/target/debug/incremental -L dependency=/home/mon/Git/menyoki/target/debug/deps --extern apng=/home/mon/Git/menyoki/target/debug/deps/libapng-8bc66a0bfd5baaf5.rmeta --extern bytesize=/home/mon/Git/menyoki/target/debug/deps/libbytesize-24920a379a7d3f04.rmeta --extern chrono=/home/mon/Git/menyoki/target/debug/deps/libchrono-3b7e79d4cc7b3d13.rmeta --extern clap=/home/mon/Git/menyoki/target/debug/deps/libclap-700fd43089bddce9.rmeta --extern colored=/home/mon/Git/menyoki/target/debug/deps/libcolored-2ae8420037ebcd63.rmeta --extern ctrlc=/home/mon/Git/menyoki/target/debug/deps/libctrlc-d159e976f2904a7a.rmeta --extern device_query=/home/mon/Git/menyoki/target/debug/deps/libdevice_query-0e39ec43acc02b0e.rmeta --extern dirs=/home/mon/Git/menyoki/target/debug/deps/libdirs-013c81d28a994e97.rmeta --extern dominant_color=/home/mon/Git/menyoki/target/debug/deps/libdominant_color-bab85d5cfc3b6e77.rmeta --extern fern_colored=/home/mon/Git/menyoki/target/debug/deps/libfern_colored-6e3ddffdba8a1142.rmeta --extern gif=/home/mon/Git/menyoki/target/debug/deps/libgif-4e5e110f2cd51696.rmeta --extern gifski=/home/mon/Git/menyoki/target/debug/deps/libgifski-48c2ff52bf1a10de.rmeta --extern hex=/home/mon/Git/menyoki/target/debug/deps/libhex-1224e69de6972fd1.rmeta --extern image=/home/mon/Git/menyoki/target/debug/deps/libimage-759c3c821d2825a2.rmeta --extern imgref=/home/mon/Git/menyoki/target/debug/deps/libimgref-9fc7f8f8819e700c.rmeta --extern exif=/home/mon/Git/menyoki/target/debug/deps/libexif-cde206a5cc55d0b0.rmeta --extern log=/home/mon/Git/menyoki/target/debug/deps/liblog-04c3ff028bf49915.rmeta --extern natord=/home/mon/Git/menyoki/target/debug/deps/libnatord-d2f7798d7ebd474c.rmeta --extern png=/home/mon/Git/menyoki/target/debug/deps/libpng-4a9c30e0737a9403.rmeta --extern rgb=/home/mon/Git/menyoki/target/debug/deps/librgb-9dee233c713ece2e.rmeta --extern ini=/home/mon/Git/menyoki/target/debug/deps/libini-231a6254d380dc7e.rmeta --extern x11=/home/mon/Git/menyoki/target/debug/deps/libx11-64a4b415bdea17f1.rmeta -L native=/usr/lib -L native=/usr/lib -L native=/home/mon/Git/menyoki/target/debug/build/imagequant-sys-90e7f4c8b1b44d0a/out`
error: This sequence of operators looks suspiciously like a bug.
   --> src/settings.rs:161:32
    |
161 |                 if geometry.height == 0 || geometry.height > ico_geometry.width {
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: I think you meant: `geometry.height > ico_geometry.height`
    |
    = note: `-D clippy::suspicious-operation-groupings` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_operation_groupings

error: aborting due to previous error

error: could not compile `menyoki`

Caused by:
  process didn't exit successfully: `/home/mon/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/clippy-driver rustc --crate-name menyoki --edition=2018 src/main.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,metadata -C opt-level=2 -C panic=abort -C embed-bitcode=no -C debuginfo=2 -C debug-assertions=on --cfg 'feature="default"' --cfg 'feature="gifski"' --cfg 'feature="imgref"' --cfg 'feature="rgb"' --cfg 'feature="ski"' -C metadata=74d57682c096c4a4 -C extra-filename=-74d57682c096c4a4 --out-dir /home/mon/Git/menyoki/target/debug/deps -C incremental=/home/mon/Git/menyoki/target/debug/incremental -L dependency=/home/mon/Git/menyoki/target/debug/deps --extern apng=/home/mon/Git/menyoki/target/debug/deps/libapng-8bc66a0bfd5baaf5.rmeta --extern bytesize=/home/mon/Git/menyoki/target/debug/deps/libbytesize-24920a379a7d3f04.rmeta --extern chrono=/home/mon/Git/menyoki/target/debug/deps/libchrono-3b7e79d4cc7b3d13.rmeta --extern clap=/home/mon/Git/menyoki/target/debug/deps/libclap-700fd43089bddce9.rmeta --extern colored=/home/mon/Git/menyoki/target/debug/deps/libcolored-2ae8420037ebcd63.rmeta --extern ctrlc=/home/mon/Git/menyoki/target/debug/deps/libctrlc-d159e976f2904a7a.rmeta --extern device_query=/home/mon/Git/menyoki/target/debug/deps/libdevice_query-0e39ec43acc02b0e.rmeta --extern dirs=/home/mon/Git/menyoki/target/debug/deps/libdirs-013c81d28a994e97.rmeta --extern dominant_color=/home/mon/Git/menyoki/target/debug/deps/libdominant_color-bab85d5cfc3b6e77.rmeta --extern fern_colored=/home/mon/Git/menyoki/target/debug/deps/libfern_colored-6e3ddffdba8a1142.rmeta --extern gif=/home/mon/Git/menyoki/target/debug/deps/libgif-4e5e110f2cd51696.rmeta --extern gifski=/home/mon/Git/menyoki/target/debug/deps/libgifski-48c2ff52bf1a10de.rmeta --extern hex=/home/mon/Git/menyoki/target/debug/deps/libhex-1224e69de6972fd1.rmeta --extern image=/home/mon/Git/menyoki/target/debug/deps/libimage-759c3c821d2825a2.rmeta --extern imgref=/home/mon/Git/menyoki/target/debug/deps/libimgref-9fc7f8f8819e700c.rmeta --extern exif=/home/mon/Git/menyoki/target/debug/deps/libexif-cde206a5cc55d0b0.rmeta --extern log=/home/mon/Git/menyoki/target/debug/deps/liblog-04c3ff028bf49915.rmeta --extern natord=/home/mon/Git/menyoki/target/debug/deps/libnatord-d2f7798d7ebd474c.rmeta --extern png=/home/mon/Git/menyoki/target/debug/deps/libpng-4a9c30e0737a9403.rmeta --extern rgb=/home/mon/Git/menyoki/target/debug/deps/librgb-9dee233c713ece2e.rmeta --extern ini=/home/mon/Git/menyoki/target/debug/deps/libini-231a6254d380dc7e.rmeta --extern x11=/home/mon/Git/menyoki/target/debug/deps/libx11-64a4b415bdea17f1.rmeta -L native=/usr/lib -L native=/usr/lib -L native=/home/mon/Git/menyoki/target/debug/build/imagequant-sys-90e7f4c8b1b44d0a/out` (exit code: 1)
```
I'm not really sure about this, neither

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌱 New feature (non-breaking change which adds functionality)
- [ ] 🌵 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation (no code change)
- [ ] 🧹 Refactor (refactoring production code)
- [ ] ⚙️ Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] 🎨 My code follows the code style of this project.
- [x] 📚 I have updated the _documentation_ accordingly.
  - [x] I have updated the [README.md](https://github.com/orhun/menyoki/blob/master/README.md)
  - [ ] I have updated the [CHANGELOG.md](https://github.com/orhun/menyoki/blob/master/CHANGELOG.md)
  - [ ] I have updated the [IMPLEMENTATION.md](https://github.com/orhun/menyoki/blob/master/IMPLEMENTATION.md)
  - [ ] I have updated the [configuration file](https://github.com/orhun/menyoki/blob/master/config/menyoki.conf).
  - [ ] I have updated the [man pages](https://github.com/orhun/menyoki/tree/master/man).
- [ ] 📐 I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] 📊 I have added tests to cover my changes.
- [ ] 📈 All new and existing tests passed.
- [ ] 📎 [Clippy](https://github.com/rust-lang/rust-clippy) is not complaining.
